### PR TITLE
Allow to continue partial downloads

### DIFF
--- a/roles/mysql-cluster-data/tasks/main.yml
+++ b/roles/mysql-cluster-data/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Download binaries
-  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
+  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
 - name: Extract binaries
   command: tar -C /var/tmp -xzf /var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64
 - name: Install nbd binaries

--- a/roles/mysql-cluster-data/tasks/main.yml
+++ b/roles/mysql-cluster-data/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Download binaries
-  command: wget -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
+  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
 - name: Extract binaries
   command: tar -C /var/tmp -xzf /var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64
 - name: Install nbd binaries

--- a/roles/mysql-cluster-mgm/tasks/main.yml
+++ b/roles/mysql-cluster-mgm/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Download binaries
-  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
+  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
 - name: Extract binaries
   command: tar -C /var/tmp -xzf /var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64/
 - name: Install nbd binaries

--- a/roles/mysql-cluster-mgm/tasks/main.yml
+++ b/roles/mysql-cluster-mgm/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Download binaries
-  command: wget -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
+  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
 - name: Extract binaries
   command: tar -C /var/tmp -xzf /var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64/
 - name: Install nbd binaries

--- a/roles/mysql-cluster-sql/tasks/main.yml
+++ b/roles/mysql-cluster-sql/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Install dependencies
   apt: pkg=libaio1
 - name: Download binaries
-  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
+  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
 - name: Extract binaries
   command: tar -C /usr/local -xzf /var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/usr/local/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64
 - name: Link binary directory to short name

--- a/roles/mysql-cluster-sql/tasks/main.yml
+++ b/roles/mysql-cluster-sql/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Install dependencies
   apt: pkg=libaio1
 - name: Download binaries
-  command: wget -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
+  command: wget --continue -P /var/tmp http://dev.mysql.com/get/Downloads/MySQL-Cluster-7.3/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz
 - name: Extract binaries
   command: tar -C /usr/local -xzf /var/tmp/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64.tar.gz creates=/usr/local/mysql-cluster-gpl-7.3.4-linux-glibc2.5-x86_64
 - name: Link binary directory to short name


### PR DESCRIPTION
The inicial downloads are as big as half gigabyte, and Ansible does not inform any progress. If one interrupts this lengthy download, and try again it will unpack the bad package and error.

Changed behaviour to always try to continue the download. Does not harm if already done and fixes if interrupted.